### PR TITLE
 Distractor format corrected

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/quiz-javascript-variables-and-data-types/66edc25ae5ea80bf6f785552.md
+++ b/curriculum/challenges/english/25-front-end-development/quiz-javascript-variables-and-data-types/66edc25ae5ea80bf6f785552.md
@@ -414,9 +414,7 @@ Which of the following is NOT a valid string concatenation method in JavaScript?
 
 ---
 
-```js
-console.log(`${string1} ${string2}`);
-```
+```console.log(`${string1} ${string2}`);```
 
 ---
 


### PR DESCRIPTION
issue #56643
corrected the distractor format to:```console.log(`${string1} ${string2}`);```

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
